### PR TITLE
refactor(runtime): 清理 runtime 抽象层遗留的 P2 项

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,7 +232,7 @@ target_link_libraries(mqtt_parser
     -Wl,-Bdynamic
     OpenSSL::SSL
     OpenSSL::Crypto
-    ${LLHTTP_LIBRARIES}
+    ${LLHTTP_LINK_LIBRARIES}
 )
 
 # 添加主程序
@@ -320,15 +320,14 @@ target_include_directories(simple_websocket_mqtt_test PUBLIC
     ${MQTTS_INCLUDE_DIRS}
 )
 
+# OpenSSL 与 llhttp 由 mqtt_parser 传播过来；在这里重复声明会让链接器把它们排到
+# mqtt_parser 的 -Wl,-Bstatic 区间里，从而尝试静态链接只有动态版本的 llhttp。
 target_link_libraries(simple_websocket_mqtt_test
     mqtt_parser
     mqtt_runtime
     tcmalloc_minimal
     pthread
     dl
-    OpenSSL::SSL
-    OpenSSL::Crypto
-    ${LLHTTP_LIBRARIES}
 )
 
 # 启用测试

--- a/src/common/logger.cpp
+++ b/src/common/logger.cpp
@@ -9,20 +9,20 @@ namespace mqtt_log_ctx {
 const char* const kDefaultTraceId = "-";
 
 namespace {
-pthread_key_t g_trace_id_key = 0;
+mqtt::runtime::TaskLocalKey g_trace_id_key;
 pthread_once_t g_trace_id_once = PTHREAD_ONCE_INIT;
 const std::string g_default_trace_id(kDefaultTraceId);
 
 void make_trace_id_key()
 {
-  (void)pthread_key_create(&g_trace_id_key, NULL);
+  (void)mqtt::runtime::current_runtime().create_task_local_key(&g_trace_id_key);
 }
 
 const std::string* get_trace_id_ptr()
 {
   pthread_once(&g_trace_id_once, make_trace_id_key);
   return static_cast<const std::string*>(
-      mqtt::runtime::current_runtime().get_specific(g_trace_id_key));
+      mqtt::runtime::current_runtime().get_task_local(g_trace_id_key));
 }
 }  // namespace
 
@@ -36,13 +36,13 @@ void bind_trace_id(const std::string& trace_id)
 {
   pthread_once(&g_trace_id_once, make_trace_id_key);
   const std::string& non_empty_trace_id = trace_id.empty() ? g_default_trace_id : trace_id;
-  (void)mqtt::runtime::current_runtime().set_specific(g_trace_id_key, &non_empty_trace_id);
+  (void)mqtt::runtime::current_runtime().set_task_local(g_trace_id_key, &non_empty_trace_id);
 }
 
 void clear_trace_id()
 {
   pthread_once(&g_trace_id_once, make_trace_id_key);
-  (void)mqtt::runtime::current_runtime().set_specific(g_trace_id_key, NULL);
+  (void)mqtt::runtime::current_runtime().set_task_local(g_trace_id_key, NULL);
 }
 
 const std::string& current_trace_id()

--- a/src/core/mqtt_socket.cpp
+++ b/src/core/mqtt_socket.cpp
@@ -60,7 +60,7 @@ int MQTTSocket::listen(const char* ip, int port, bool reuse, int backlog)
   }
 
   if (MQ_SUCC(ret)) {
-    mqtt::runtime::current_runtime().enable_hook();
+    mqtt::runtime::current_runtime().enable_async_syscalls();
     LOG_INFO("Socket listening on {}:{} (backlog: {})", ip, port, backlog);
   }
 

--- a/src/runtime/libco_runtime.cpp
+++ b/src/runtime/libco_runtime.cpp
@@ -1,5 +1,6 @@
 #include "mqtt_runtime.h"
 
+#include <pthread.h>
 #include <atomic>
 #include <cerrno>
 #include <chrono>
@@ -15,6 +16,9 @@ namespace mqtt {
 namespace runtime {
 
 namespace {
+
+// Size of the per-coroutine slot array libco indexes with a pthread key value.
+const pthread_key_t kMaxTaskLocalKeys = 1024;
 
 // A libco coroutine may only be resumed or freed by the thread that created it,
 // and its stack stays live until it has yielded for the last time. The lifecycle
@@ -290,7 +294,7 @@ int TaskHandle::join(int timeout_ms)
   return 0;
 }
 
-AsyncMutex::AsyncMutex() : impl_(nullptr)
+CoroutineMutex::CoroutineMutex() : impl_(nullptr)
 {
   MutexState* state = new MutexState();
   state->cond = co_cond_alloc();
@@ -303,7 +307,7 @@ AsyncMutex::AsyncMutex() : impl_(nullptr)
   impl_ = state;
 }
 
-AsyncMutex::~AsyncMutex()
+CoroutineMutex::~CoroutineMutex()
 {
   MutexState* state = static_cast<MutexState*>(impl_);
   if (state) {
@@ -313,7 +317,7 @@ AsyncMutex::~AsyncMutex()
   }
 }
 
-void AsyncMutex::lock()
+void CoroutineMutex::lock()
 {
   MutexState* state = static_cast<MutexState*>(impl_);
   if (!state) {
@@ -331,7 +335,7 @@ void AsyncMutex::lock()
   // taken without waiting rather than corrupting libco's call stack.
 }
 
-void AsyncMutex::unlock()
+void CoroutineMutex::unlock()
 {
   MutexState* state = static_cast<MutexState*>(impl_);
   if (!state) {
@@ -344,21 +348,21 @@ void AsyncMutex::unlock()
   }
 }
 
-AsyncLockGuard::AsyncLockGuard(AsyncMutex* mutex) : mutex_(mutex)
+CoroutineLockGuard::CoroutineLockGuard(CoroutineMutex* mutex) : mutex_(mutex)
 {
   if (mutex_) {
     mutex_->lock();
   }
 }
 
-AsyncLockGuard::~AsyncLockGuard()
+CoroutineLockGuard::~CoroutineLockGuard()
 {
   if (mutex_) {
     mutex_->unlock();
   }
 }
 
-AsyncCondition::AsyncCondition() : impl_(nullptr)
+CoroutineCondition::CoroutineCondition() : impl_(nullptr)
 {
   ConditionState* state = new ConditionState();
   state->cond = co_cond_alloc();
@@ -370,7 +374,7 @@ AsyncCondition::AsyncCondition() : impl_(nullptr)
   impl_ = state;
 }
 
-AsyncCondition::~AsyncCondition()
+CoroutineCondition::~CoroutineCondition()
 {
   ConditionState* state = static_cast<ConditionState*>(impl_);
   if (state) {
@@ -380,12 +384,12 @@ AsyncCondition::~AsyncCondition()
   }
 }
 
-AsyncCondition::AsyncCondition(AsyncCondition&& other) noexcept : impl_(other.impl_)
+CoroutineCondition::CoroutineCondition(CoroutineCondition&& other) noexcept : impl_(other.impl_)
 {
   other.impl_ = nullptr;
 }
 
-AsyncCondition& AsyncCondition::operator=(AsyncCondition&& other) noexcept
+CoroutineCondition& CoroutineCondition::operator=(CoroutineCondition&& other) noexcept
 {
   if (this != &other) {
     ConditionState* state = static_cast<ConditionState*>(impl_);
@@ -399,7 +403,7 @@ AsyncCondition& AsyncCondition::operator=(AsyncCondition&& other) noexcept
   return *this;
 }
 
-int AsyncCondition::wait(int timeout_ms)
+int CoroutineCondition::wait(int timeout_ms)
 {
   ConditionState* state = static_cast<ConditionState*>(impl_);
   if (!state) {
@@ -423,63 +427,43 @@ int AsyncCondition::wait(int timeout_ms)
   return co_cond_timedwait(state->cond, timeout_ms);
 }
 
-bool AsyncCondition::can_wake() const
+bool CoroutineCondition::can_wake() const
 {
   const ConditionState* state = static_cast<const ConditionState*>(impl_);
   return state && can_wake_waiter(state->waiter_env);
 }
 
-void AsyncCondition::signal()
+void CoroutineCondition::signal()
 {
   if (can_wake()) {
     co_cond_signal(static_cast<ConditionState*>(impl_)->cond);
   }
 }
 
-void AsyncCondition::broadcast()
+void CoroutineCondition::broadcast()
 {
   if (can_wake()) {
     co_cond_broadcast(static_cast<ConditionState*>(impl_)->cond);
   }
 }
 
-int IoWaiter::wait(int fd, short events, int timeout_ms)
+Runtime& Runtime::instance()
 {
-  return current_runtime().wait(fd, events, timeout_ms);
-}
-
-int IoWaiter::wait_readable(int fd, int timeout_ms)
-{
-  return current_runtime().wait_readable(fd, timeout_ms);
-}
-
-int IoWaiter::wait_writable(int fd, int timeout_ms)
-{
-  return current_runtime().wait_writable(fd, timeout_ms);
-}
-
-LibcoRuntime& LibcoRuntime::instance()
-{
-  static LibcoRuntime runtime;
+  static Runtime runtime;
   return runtime;
 }
 
-void LibcoRuntime::enable_hook()
+void Runtime::enable_async_syscalls()
 {
   co_enable_hook_sys();
 }
 
-void LibcoRuntime::disable_hook()
+void Runtime::disable_async_syscalls()
 {
   co_disable_hook_sys();
 }
 
-IoWaiter& LibcoRuntime::io_waiter()
-{
-  return io_waiter_;
-}
-
-TaskHandle LibcoRuntime::spawn(TaskEntry entry, void* arg, size_t stack_size)
+TaskHandle Runtime::spawn(TaskEntry entry, void* arg, size_t stack_size)
 {
   if (!entry) {
     return TaskHandle();
@@ -513,7 +497,7 @@ TaskHandle LibcoRuntime::spawn(TaskEntry entry, void* arg, size_t stack_size)
   return TaskHandle(state);
 }
 
-int LibcoRuntime::run_event_loop(EventLoopCallback callback, void* arg)
+int Runtime::run_event_loop(EventLoopCallback callback, void* arg)
 {
   EventLoopContext ctx = {callback, arg};
   co_eventloop(co_get_epoll_ct(), eventloop_trampoline, &ctx);
@@ -521,13 +505,13 @@ int LibcoRuntime::run_event_loop(EventLoopCallback callback, void* arg)
   return 0;
 }
 
-int LibcoRuntime::reap_tasks()
+int Runtime::reap_tasks()
 {
   reap_finished_tasks();
   return 0;
 }
 
-int LibcoRuntime::wait(int fd, short events, int timeout_ms)
+int Runtime::wait(int fd, short events, int timeout_ms)
 {
   struct pollfd pf;
   std::memset(&pf, 0, sizeof(pf));
@@ -543,42 +527,68 @@ int LibcoRuntime::wait(int fd, short events, int timeout_ms)
   return co_poll(co_get_epoll_ct(), &pf, 1, timeout_ms);
 }
 
-int LibcoRuntime::wait_readable(int fd, int timeout_ms)
+int Runtime::wait_readable(int fd, int timeout_ms)
 {
   return wait(fd, POLLIN | POLLERR | POLLHUP, timeout_ms);
 }
 
-int LibcoRuntime::wait_writable(int fd, int timeout_ms)
+int Runtime::wait_writable(int fd, int timeout_ms)
 {
   return wait(fd, POLLOUT | POLLERR | POLLHUP, timeout_ms);
 }
 
-int LibcoRuntime::accept(int fd, struct sockaddr* addr, socklen_t* len)
+int Runtime::accept(int fd, struct sockaddr* addr, socklen_t* len)
 {
   return co_accept(fd, addr, len);
 }
 
-void* LibcoRuntime::get_specific(pthread_key_t key)
+int Runtime::create_task_local_key(TaskLocalKey* key)
 {
-  if (key >= kMaxTaskLocalKeys) {
-    return nullptr;
-  }
-  return co_getspecific(key);
-}
-
-int LibcoRuntime::set_specific(pthread_key_t key, const void* value)
-{
-  // libco indexes a fixed-size per-coroutine array without validating the key.
-  if (key >= kMaxTaskLocalKeys) {
+  if (!key) {
     errno = EINVAL;
     return -1;
   }
-  return co_setspecific(key, value);
+
+  pthread_key_t native_key = 0;
+  int ret = pthread_key_create(&native_key, nullptr);
+  if (ret != 0) {
+    errno = ret;
+    return -1;
+  }
+
+  // libco indexes a fixed-size per-coroutine array with the raw key value and
+  // never validates it, so a key beyond that array is unusable here.
+  if (native_key >= kMaxTaskLocalKeys) {
+    pthread_key_delete(native_key);
+    errno = EINVAL;
+    return -1;
+  }
+
+  key->slot_ = static_cast<unsigned int>(native_key);
+  key->valid_ = true;
+  return 0;
 }
 
-LibcoRuntime& current_runtime()
+void* Runtime::get_task_local(const TaskLocalKey& key)
 {
-  return LibcoRuntime::instance();
+  if (!key.is_valid()) {
+    return nullptr;
+  }
+  return co_getspecific(static_cast<pthread_key_t>(key.slot_));
+}
+
+int Runtime::set_task_local(const TaskLocalKey& key, const void* value)
+{
+  if (!key.is_valid()) {
+    errno = EINVAL;
+    return -1;
+  }
+  return co_setspecific(static_cast<pthread_key_t>(key.slot_), value);
+}
+
+Runtime& current_runtime()
+{
+  return Runtime::instance();
 }
 
 }  // namespace runtime

--- a/src/runtime/mqtt_runtime.h
+++ b/src/runtime/mqtt_runtime.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <pthread.h>
 #include <sys/socket.h>
 #include <poll.h>
 #include <cstddef>
@@ -11,8 +10,7 @@ namespace runtime {
 typedef void* (*TaskEntry)(void*);
 typedef int (*EventLoopCallback)(void*);
 
-// Upper bound of the per-task local storage slots offered by the backend.
-const pthread_key_t kMaxTaskLocalKeys = 1024;
+class Runtime;
 
 /**
  * @brief 协程任务句柄。
@@ -52,7 +50,7 @@ class TaskHandle
   void release();
 
  private:
-  friend class LibcoRuntime;
+  friend class Runtime;
 
   explicit TaskHandle(void* task);
 
@@ -64,14 +62,14 @@ class TaskHandle
  *
  * 非协程上下文没有可让出的目标，此时 lock() 不会等待而直接进入临界区。
  */
-class AsyncMutex
+class CoroutineMutex
 {
  public:
-  AsyncMutex();
-  ~AsyncMutex();
+  CoroutineMutex();
+  ~CoroutineMutex();
 
-  AsyncMutex(const AsyncMutex&) = delete;
-  AsyncMutex& operator=(const AsyncMutex&) = delete;
+  CoroutineMutex(const CoroutineMutex&) = delete;
+  CoroutineMutex& operator=(const CoroutineMutex&) = delete;
 
   void lock();
   void unlock();
@@ -80,17 +78,17 @@ class AsyncMutex
   void* impl_;
 };
 
-class AsyncLockGuard
+class CoroutineLockGuard
 {
  public:
-  explicit AsyncLockGuard(AsyncMutex* mutex);
-  ~AsyncLockGuard();
+  explicit CoroutineLockGuard(CoroutineMutex* mutex);
+  ~CoroutineLockGuard();
 
-  AsyncLockGuard(const AsyncLockGuard&) = delete;
-  AsyncLockGuard& operator=(const AsyncLockGuard&) = delete;
+  CoroutineLockGuard(const CoroutineLockGuard&) = delete;
+  CoroutineLockGuard& operator=(const CoroutineLockGuard&) = delete;
 
  private:
-  AsyncMutex* mutex_;
+  CoroutineMutex* mutex_;
 };
 
 /**
@@ -98,17 +96,17 @@ class AsyncLockGuard
  *
  * 移动操作只搬移内部指针，存在等待者时移动是未定义行为。
  */
-class AsyncCondition
+class CoroutineCondition
 {
  public:
-  AsyncCondition();
-  ~AsyncCondition();
+  CoroutineCondition();
+  ~CoroutineCondition();
 
-  AsyncCondition(const AsyncCondition&) = delete;
-  AsyncCondition& operator=(const AsyncCondition&) = delete;
+  CoroutineCondition(const CoroutineCondition&) = delete;
+  CoroutineCondition& operator=(const CoroutineCondition&) = delete;
 
-  AsyncCondition(AsyncCondition&& other) noexcept;
-  AsyncCondition& operator=(AsyncCondition&& other) noexcept;
+  CoroutineCondition(CoroutineCondition&& other) noexcept;
+  CoroutineCondition& operator=(CoroutineCondition&& other) noexcept;
 
   /**
    * @brief 挂起当前协程直到被唤醒或超时。
@@ -132,25 +130,42 @@ class AsyncCondition
   void* impl_;
 };
 
-class IoWaiter
+/**
+ * @brief 任务本地存储的键，只能由 Runtime::create_task_local_key() 分配。
+ *
+ * 默认构造出来的键是无效的，用它读写会失败。键的可用数量由运行时决定，
+ * 分配后不会回收，因此适合进程级的长生命周期用途。
+ */
+class TaskLocalKey
 {
  public:
-  // timeout_ms == 0 或调用方不在协程上下文时退化为真实的 ::poll()。
-  int wait(int fd, short events, int timeout_ms);
-  int wait_readable(int fd, int timeout_ms);
-  int wait_writable(int fd, int timeout_ms);
+  constexpr TaskLocalKey() : slot_(0), valid_(false) {}
+
+  bool is_valid() const { return valid_; }
+
+ private:
+  friend class Runtime;
+
+  unsigned int slot_;
+  bool valid_;
 };
 
-class LibcoRuntime
+/**
+ * @brief 协程运行时。所有协程相关能力都从这里获取，后端实现不对外暴露。
+ */
+class Runtime
 {
  public:
-  static LibcoRuntime& instance();
+  static Runtime& instance();
 
-  // 系统调用拦截只对当前协程生效，每个需要它的协程都要自行开启。
-  void enable_hook();
-  void disable_hook();
-
-  IoWaiter& io_waiter();
+  /**
+   * @brief 让当前任务里的阻塞式系统调用（read/write/connect/poll 等）自动改为
+   *        挂起任务、就绪后恢复。
+   *
+   * 该开关只对调用它的任务生效，每个需要它的任务都要自行开启。
+   */
+  void enable_async_syscalls();
+  void disable_async_syscalls();
 
   /**
    * @brief 在当前线程创建并立即启动一个任务。
@@ -170,24 +185,27 @@ class LibcoRuntime
   int wait_writable(int fd, int timeout_ms);
   int accept(int fd, struct sockaddr* addr, socklen_t* len);
 
-  void* get_specific(pthread_key_t key);
-  int set_specific(pthread_key_t key, const void* value);
+  /**
+   * @brief 分配一个任务本地存储键。
+   * @return 0 表示成功；-1 并设置 errno，键的数量超出运行时上限时为 EINVAL。
+   */
+  int create_task_local_key(TaskLocalKey* key);
+
+  // 读写当前任务的本地存储。非协程上下文回退为线程本地存储。
+  void* get_task_local(const TaskLocalKey& key);
+  int set_task_local(const TaskLocalKey& key, const void* value);
 
  private:
-  LibcoRuntime() = default;
-  ~LibcoRuntime() = default;
+  Runtime() = default;
+  ~Runtime() = default;
 
-  LibcoRuntime(const LibcoRuntime&) = delete;
-  LibcoRuntime& operator=(const LibcoRuntime&) = delete;
-
-  IoWaiter io_waiter_;
+  Runtime(const Runtime&) = delete;
+  Runtime& operator=(const Runtime&) = delete;
 };
 
-using Runtime = LibcoRuntime;
-
-// 进程级单例。libco 的调度状态本身是线程本地的，因此同一个 Runtime 对象在不同
-// 线程上操作的是各自线程的事件循环。
-LibcoRuntime& current_runtime();
+// 进程级单例。运行时的调度状态是线程本地的，因此同一个 Runtime 对象在不同线程上
+// 操作的是各自线程的事件循环。
+Runtime& current_runtime();
 
 }  // namespace runtime
 }  // namespace mqtt

--- a/src/utils/mqtt_coroutine_utils.h
+++ b/src/utils/mqtt_coroutine_utils.h
@@ -8,14 +8,14 @@ namespace mqtt {
 /**
  * @brief 协程友好的锁类型。具体运行时实现隐藏在 runtime 层。
  */
-using CoroMutex = runtime::AsyncMutex;
+using CoroMutex = runtime::CoroutineMutex;
 
 /**
  * @brief 协程锁的RAII包装器。
  */
-using CoroLockGuard = runtime::AsyncLockGuard;
+using CoroLockGuard = runtime::CoroutineLockGuard;
 
-using CoroCondition = runtime::AsyncCondition;
+using CoroCondition = runtime::CoroutineCondition;
 
 }  // namespace mqtt
 

--- a/unittest/coroutine_test_helper.h
+++ b/unittest/coroutine_test_helper.h
@@ -1,134 +1,46 @@
 #ifndef COROUTINE_TEST_HELPER_H
 #define COROUTINE_TEST_HELPER_H
 
-#include "../3rd/libco/co_routine.h"
-#include "../3rd/libco/co_comm.h"
-#include <memory>
-#include <functional>
-#include <atomic>
+#include "mqtt_runtime.h"
 
 namespace mqtt {
 namespace test {
 
 /**
- * @brief 协程测试辅助类，用于在测试环境中正确初始化和运行协程代码
+ * @brief RAII包装器，用于在测试中安全地使用协程环境。
+ *
+ * 构造时开启当前任务的异步系统调用，并跑一个空任务确认运行时可用；析构时把
+ * 开关恢复并回收本线程遗留的任务。
  */
-class CoroutineTestHelper {
-public:
-    CoroutineTestHelper() : main_co_(nullptr), test_co_(nullptr) {
-        // 启用系统调用hook，这对协程正常工作很重要
-        co_enable_hook_sys();
-        
-        // 获取当前线程的epoll上下文，这会初始化协程环境
-        epoll_ctx_ = co_get_epoll_ct();
-    }
-    
-    ~CoroutineTestHelper() {
-        if (test_co_) {
-            co_release(test_co_);
-            test_co_ = nullptr;
-        }
-        co_disable_hook_sys();
-    }
-    
-    /**
-     * @brief 在协程环境中运行测试函数
-     * @param test_func 要运行的测试函数
-     * @return true 如果测试成功运行，false 如果无法创建协程
-     */
-    bool run_in_coroutine(std::function<void()> test_func) {
-        test_function_ = test_func;
-        
-        // 创建测试协程
-        int ret = co_create(&test_co_, nullptr, &CoroutineTestHelper::coroutine_entry, this);
-        if (ret != 0) {
-            return false;
-        }
-        
-        // 启动协程
-        co_resume(test_co_);
-        
-        return true;
-    }
-    
-    /**
-     * @brief 检查当前环境是否支持协程
-     * @return true 如果支持协程，false 如果不支持
-     */
-    static bool is_coroutine_supported() {
-        // 尝试获取epoll上下文来测试协程是否可用
-        stCoEpoll_t* ctx = co_get_epoll_ct();
-        return ctx != nullptr;
-    }
-    
-    /**
-     * @brief 简单的协程yield操作，用于测试协程切换
-     */
-    void yield() {
-        co_yield_ct();
-    }
+class CoroutineTestScope
+{
+ public:
+  CoroutineTestScope() : available_(false)
+  {
+    runtime::current_runtime().enable_async_syscalls();
 
-private:
-    static void* coroutine_entry(void* arg) {
-        CoroutineTestHelper* helper = static_cast<CoroutineTestHelper*>(arg);
-        if (helper && helper->test_function_) {
-            helper->test_function_();
-        }
-        return nullptr;
-    }
-    
-    stCoRoutine_t* main_co_;
-    stCoRoutine_t* test_co_;
-    stCoEpoll_t* epoll_ctx_;
-    std::function<void()> test_function_;
+    runtime::TaskHandle probe = runtime::current_runtime().spawn(&probe_task, nullptr);
+    available_ = probe.is_valid() && probe.is_finished();
+  }
+
+  ~CoroutineTestScope()
+  {
+    runtime::current_runtime().reap_tasks();
+    runtime::current_runtime().disable_async_syscalls();
+  }
+
+  CoroutineTestScope(const CoroutineTestScope&) = delete;
+  CoroutineTestScope& operator=(const CoroutineTestScope&) = delete;
+
+  bool is_available() const { return available_; }
+
+ private:
+  static void* probe_task(void* /*arg*/) { return nullptr; }
+
+  bool available_;
 };
 
-/**
- * @brief RAII包装器，用于在测试中安全地使用协程环境
- */
-class CoroutineTestScope {
-public:
-    CoroutineTestScope() : epoll_ctx_(nullptr), dummy_co_(nullptr) {
-        // 启用协程环境
-        co_enable_hook_sys();
-        
-        // 获取epoll上下文
-        epoll_ctx_ = co_get_epoll_ct();
-        
-        // 创建一个简单的dummy协程来初始化环境
-        int ret = co_create(&dummy_co_, nullptr, &dummy_routine, nullptr);
-        if (ret == 0 && dummy_co_) {
-            // 启动并立即完成协程
-            co_resume(dummy_co_);
-        }
-    }
-    
-    ~CoroutineTestScope() {
-        // 清理dummy协程
-        if (dummy_co_) {
-            co_release(dummy_co_);
-            dummy_co_ = nullptr;
-        }
-        
-        // 清理协程环境
-        co_disable_hook_sys();
-    }
-    
-    bool is_available() const {
-        return epoll_ctx_ != nullptr && dummy_co_ != nullptr;
-    }
-    
-private:
-    static void* dummy_routine(void* arg) {
-        // 什么都不做，只是为了初始化协程环境
-        return nullptr;
-    }
-    
-    stCoEpoll_t* epoll_ctx_;
-    stCoRoutine_t* dummy_co_;
-};
+}  // namespace test
+}  // namespace mqtt
 
-} // namespace test
-} // namespace mqtt
-
-#endif // COROUTINE_TEST_HELPER_H
+#endif  // COROUTINE_TEST_HELPER_H

--- a/unittest/test_mqtt_runtime.cpp
+++ b/unittest/test_mqtt_runtime.cpp
@@ -25,7 +25,7 @@ struct WaitContext
 
 struct MutexContext
 {
-  mqtt::runtime::AsyncMutex* mutex;
+  mqtt::runtime::CoroutineMutex* mutex;
   std::string* order;
   const char* label;
   int hold_ms;
@@ -34,7 +34,7 @@ struct MutexContext
 
 struct ConditionContext
 {
-  mqtt::runtime::AsyncCondition* condition;
+  mqtt::runtime::CoroutineCondition* condition;
   int wait_result;
   bool woken;
 };
@@ -45,6 +45,12 @@ struct JoinAttemptContext
   int join_result;
   int join_errno;
   bool done;
+};
+
+struct TaskLocalContext
+{
+  mqtt::runtime::TaskLocalKey* key;
+  void* observed;
 };
 
 struct ThreadTaskResult
@@ -65,7 +71,7 @@ void* increment_task(void* arg)
 void* wait_readable_task(void* arg)
 {
   WaitContext* ctx = static_cast<WaitContext*>(arg);
-  ctx->result = mqtt::runtime::current_runtime().io_waiter().wait_readable(ctx->fd, 10);
+  ctx->result = mqtt::runtime::current_runtime().wait_readable(ctx->fd, 10);
   ctx->done = true;
   return nullptr;
 }
@@ -97,6 +103,14 @@ void* condition_wait_task(void* arg)
   ConditionContext* ctx = static_cast<ConditionContext*>(arg);
   ctx->wait_result = ctx->condition->wait(5000);
   ctx->woken = true;
+  return nullptr;
+}
+
+void* task_local_roundtrip_task(void* arg)
+{
+  TaskLocalContext* ctx = static_cast<TaskLocalContext*>(arg);
+  mqtt::runtime::current_runtime().set_task_local(*ctx->key, "inner");
+  ctx->observed = mqtt::runtime::current_runtime().get_task_local(*ctx->key);
   return nullptr;
 }
 
@@ -143,7 +157,7 @@ void drain_pipe_waiter(int write_fd, WaitContext* ctx)
 class RuntimeTest : public ::testing::Test
 {
  protected:
-  void SetUp() override { mqtt::runtime::current_runtime().enable_hook(); }
+  void SetUp() override { mqtt::runtime::current_runtime().enable_async_syscalls(); }
 };
 
 TEST_F(RuntimeTest, SpawnRunsTaskAndTracksFinishedState)
@@ -194,10 +208,10 @@ TEST_F(RuntimeTest, ZeroTimeoutUsesNonBlockingPollOutsideCoroutine)
   int fds[2] = {-1, -1};
   ASSERT_EQ(0, pipe(fds));
 
-  EXPECT_EQ(0, mqtt::runtime::current_runtime().io_waiter().wait_readable(fds[0], 0));
+  EXPECT_EQ(0, mqtt::runtime::current_runtime().wait_readable(fds[0], 0));
 
   ASSERT_EQ(1, write(fds[1], "x", 1));
-  EXPECT_EQ(1, mqtt::runtime::current_runtime().io_waiter().wait_readable(fds[0], 0));
+  EXPECT_EQ(1, mqtt::runtime::current_runtime().wait_readable(fds[0], 0));
 
   close(fds[0]);
   close(fds[1]);
@@ -211,7 +225,7 @@ TEST_F(RuntimeTest, BlockingWaitOutsideCoroutineFallsBackToRealPoll)
   // Without a coroutine to suspend, the wait must still block for its timeout
   // rather than fail, otherwise the socket layer's retry loops would spin.
   std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
-  int wait_ret = mqtt::runtime::current_runtime().io_waiter().wait_readable(fds[0], 50);
+  int wait_ret = mqtt::runtime::current_runtime().wait_readable(fds[0], 50);
   int64_t elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                            std::chrono::steady_clock::now() - start)
                            .count();
@@ -347,7 +361,7 @@ TEST_F(RuntimeTest, DetachedTasksAreReclaimedRepeatedly)
 
 TEST_F(RuntimeTest, MutexSerializesContendingCoroutines)
 {
-  mqtt::runtime::AsyncMutex mutex;
+  mqtt::runtime::CoroutineMutex mutex;
   std::string order;
   MutexContext contexts[2] = {{&mutex, &order, "a", 50, false},
                               {&mutex, &order, "b", 0, false}};
@@ -371,7 +385,7 @@ TEST_F(RuntimeTest, MutexSerializesContendingCoroutines)
 
 TEST_F(RuntimeTest, ConditionWakesWaitingCoroutine)
 {
-  mqtt::runtime::AsyncCondition condition;
+  mqtt::runtime::CoroutineCondition condition;
   ASSERT_TRUE(condition.is_valid());
 
   ConditionContext ctx = {&condition, -1, false};
@@ -388,7 +402,7 @@ TEST_F(RuntimeTest, ConditionWakesWaitingCoroutine)
 
 TEST_F(RuntimeTest, ConditionWaitOutsideCoroutineHonoursTimeout)
 {
-  mqtt::runtime::AsyncCondition condition;
+  mqtt::runtime::CoroutineCondition condition;
 
   std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
   EXPECT_EQ(0, condition.wait(50));
@@ -402,13 +416,39 @@ TEST_F(RuntimeTest, ConditionWaitOutsideCoroutineHonoursTimeout)
   EXPECT_EQ(EPERM, errno);
 }
 
-TEST_F(RuntimeTest, TaskLocalStorageRejectsOutOfRangeKeys)
+TEST_F(RuntimeTest, TaskLocalStorageRejectsUnallocatedKeys)
 {
+  mqtt::runtime::TaskLocalKey unallocated;
+  ASSERT_FALSE(unallocated.is_valid());
+
   errno = 0;
-  EXPECT_EQ(-1, mqtt::runtime::current_runtime().set_specific(mqtt::runtime::kMaxTaskLocalKeys, ""));
+  EXPECT_EQ(-1, mqtt::runtime::current_runtime().set_task_local(unallocated, ""));
   EXPECT_EQ(EINVAL, errno);
-  EXPECT_EQ(nullptr,
-            mqtt::runtime::current_runtime().get_specific(mqtt::runtime::kMaxTaskLocalKeys));
+  EXPECT_EQ(nullptr, mqtt::runtime::current_runtime().get_task_local(unallocated));
+
+  errno = 0;
+  EXPECT_EQ(-1, mqtt::runtime::current_runtime().create_task_local_key(nullptr));
+  EXPECT_EQ(EINVAL, errno);
+}
+
+TEST_F(RuntimeTest, TaskLocalStorageIsScopedToTheRunningTask)
+{
+  mqtt::runtime::TaskLocalKey key;
+  ASSERT_EQ(0, mqtt::runtime::current_runtime().create_task_local_key(&key));
+  ASSERT_TRUE(key.is_valid());
+
+  const char kOuterValue[] = "outer";
+  ASSERT_EQ(0, mqtt::runtime::current_runtime().set_task_local(key, kOuterValue));
+
+  TaskLocalContext ctx = {&key, nullptr};
+  mqtt::runtime::TaskHandle task =
+      mqtt::runtime::current_runtime().spawn(task_local_roundtrip_task, &ctx, 64 * 1024);
+  ASSERT_TRUE(task.is_valid());
+
+  // 任务有自己的槽位，写入不会覆盖调用方看到的值。
+  EXPECT_STREQ("inner", static_cast<const char*>(ctx.observed));
+  EXPECT_STREQ(kOuterValue,
+               static_cast<const char*>(mqtt::runtime::current_runtime().get_task_local(key)));
 }
 
 TEST_F(RuntimeTest, TasksOwnedByEachThreadRunIndependently)
@@ -420,7 +460,7 @@ TEST_F(RuntimeTest, TasksOwnedByEachThreadRunIndependently)
   for (int i = 0; i < kThreadCount; ++i) {
     ThreadTaskResult* result = &results[i];
     threads.push_back(std::thread([result]() {
-      mqtt::runtime::current_runtime().enable_hook();
+      mqtt::runtime::current_runtime().enable_async_syscalls();
 
       int fds[2] = {-1, -1};
       if (pipe(fds) != 0) {
@@ -462,7 +502,7 @@ TEST_F(RuntimeTest, TasksOwnedByEachThreadRunIndependently)
 // list, so the wakeup has to be dropped instead.
 TEST_F(RuntimeTest, ForeignThreadWakeupsAreDropped)
 {
-  mqtt::runtime::AsyncMutex mutex;
+  mqtt::runtime::CoroutineMutex mutex;
   std::string order;
   MutexContext contexts[2] = {{&mutex, &order, "a", 50, false},
                               {&mutex, &order, "b", 0, false}};
@@ -477,7 +517,7 @@ TEST_F(RuntimeTest, ForeignThreadWakeupsAreDropped)
 
   // The second task is queued on this thread's mutex; a foreign unlock/broadcast
   // must leave it there instead of resuming it.
-  mqtt::runtime::AsyncCondition condition;
+  mqtt::runtime::CoroutineCondition condition;
   ConditionContext condition_ctx = {&condition, -1, false};
   mqtt::runtime::TaskHandle waiter =
       mqtt::runtime::current_runtime().spawn(condition_wait_task, &condition_ctx, 64 * 1024);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
承接 #11 review 中记为 P2、建议另开 PR 的几项。

## 改动

### 1. 删除纯转发的 `IoWaiter`
`IoWaiter::wait/wait_readable/wait_writable` 只是把调用转回 `current_runtime()`，生产代码从来都直接用 `current_runtime().wait_*()`，只有单测走这一层。删掉后 IO 等待只有一个入口。

### 2. `Async*` 更名为 `Coroutine*`
`AsyncMutex` / `AsyncLockGuard` / `AsyncCondition` → `CoroutineMutex` / `CoroutineLockGuard` / `CoroutineCondition`。这些原语只在同一线程的协程之间生效（跨线程 signal 会被丢弃），`Async` 容易被读成线程安全的异步原语。`mqtt::CoroMutex` 等别名保持不变，因此生产代码的调用点一处都没动。

### 3. `Runtime` 成为真正的类型，不再暴露底层概念
- `using Runtime = LibcoRuntime` 去掉，`Runtime` 就是公开类型，`libco` 只出现在 `libco_runtime.cpp` 里。
- `enable_hook()` / `disable_hook()` → `enable_async_syscalls()` / `disable_async_syscalls()`。
- `get_specific(pthread_key_t)` / `set_specific(pthread_key_t, ...)` → `create_task_local_key(TaskLocalKey*)` + `get_task_local()` / `set_task_local()`。调用方不再自己 `pthread_key_create`，也不再需要知道后端槽位数组只有 1024 项；键的合法性在分配时一次性校验，`kMaxTaskLocalKeys` 退回实现文件。`logger.cpp` 相应改写。

### 4. `unittest/coroutine_test_helper.h` 不再直接调用 libco
`CoroutineTestScope` 改为通过 `Runtime` 开启异步系统调用并 spawn 一个空任务来探测运行时可用性。顺带删掉无人使用的 `CoroutineTestHelper`（它 `co_release` 时不检查协程是否已结束）。

### 5. 顺带修掉一个构建失败
`simple_websocket_mqtt_test` 在当前环境链接失败：`mqtt_parser` 通过 INTERFACE 传播 `-Wl,-Bstatic yaml-cpp -Wl,-Bdynamic`，可执行文件里重复声明 `llhttp` 会被 CMake 去重后挪进这个区间，链接器于是尝试静态链接只有动态版本的 `libllhttp`。改为只在 `mqtt_parser` 上声明一次，并用绝对路径而不是 `-l` 形式。

## 未包含

WebSocket bridge 的 publish/subscribe（`Forwarded PUBLISH message to 0 subscribers`）是既有问题，与 runtime 抽象无关，单独跟进。

## 验证

`cmake --build` + `ctest`，52/52 通过（含 `test_mqtt_runtime` 18 个用例，新增 2 个覆盖任务本地存储的分配与任务隔离语义）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b51b5c5c-058f-49cf-bb7d-d17da74bc555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b51b5c5c-058f-49cf-bb7d-d17da74bc555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

