### PR TITLE
fix(session): 发布者订阅了自己发布的主题时收不到消息

### DIFF
--- a/simple_websocket_mqtt_test.cpp
+++ b/simple_websocket_mqtt_test.cpp
@@ -35,6 +35,29 @@ std::string base64_encode(const unsigned char* input, size_t length) {
     return result;
 }
 
+// Base64 decode
+std::string base64_decode(const std::string& encoded) {
+    if (encoded.empty()) {
+        return std::string();
+    }
+
+    BIO* bio = BIO_new_mem_buf(encoded.data(), static_cast<int>(encoded.size()));
+    BIO* b64 = BIO_new(BIO_f_base64());
+    BIO_set_flags(b64, BIO_FLAGS_BASE64_NO_NL);
+    bio = BIO_push(b64, bio);
+
+    std::string result(encoded.size(), '\0');
+    int decoded_length = BIO_read(bio, &result[0], static_cast<int>(result.size()));
+    BIO_free_all(bio);
+
+    if (decoded_length <= 0) {
+        return std::string();
+    }
+
+    result.resize(decoded_length);
+    return result;
+}
+
 // Compute WebSocket accept key
 std::string compute_accept_key(const std::string& key) {
     const char* GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
@@ -97,8 +120,13 @@ std::vector<uint8_t> create_websocket_frame(uint8_t opcode, const std::string& p
     return frame;
 }
 
-// Parse WebSocket frame
-bool parse_websocket_frame(const uint8_t* data, size_t len, uint8_t& opcode, std::string& payload) {
+// Parse one WebSocket frame from the front of a byte stream.
+// Returns false when the buffer does not hold a complete frame yet; on success
+// frame_len tells the caller how many bytes to drop from the buffer, because a
+// single read can carry several frames.
+bool parse_websocket_frame(const uint8_t* data, size_t len, uint8_t& opcode, std::string& payload,
+                           size_t& frame_len) {
+    frame_len = 0;
     if (len < 2) {
         return false;
     }
@@ -146,6 +174,7 @@ bool parse_websocket_frame(const uint8_t* data, size_t len, uint8_t& opcode, std
         payload.push_back(byte);
     }
 
+    frame_len = offset + payload_len;
     return fin;
 }
 
@@ -257,55 +286,62 @@ public:
             return false;
         }
 
-        // Set timeout
-        struct timeval tv;
-        tv.tv_sec = timeout_ms / 1000;
-        tv.tv_usec = (timeout_ms % 1000) * 1000;
-        setsockopt(sockfd_, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+        // The server may pack several frames into one read, so frames are taken
+        // from a persistent buffer and the socket is only read when that buffer
+        // has no complete frame left.
+        for (;;) {
+            uint8_t opcode = 0;
+            std::string frame_payload;
+            size_t frame_len = 0;
+            while (!recv_buffer_.empty() &&
+                   parse_websocket_frame(recv_buffer_.data(), recv_buffer_.size(), opcode,
+                                         frame_payload, frame_len)) {
+                recv_buffer_.erase(recv_buffer_.begin(), recv_buffer_.begin() + frame_len);
 
-        // Read data
-        uint8_t buffer[65536];
-        ssize_t n = recv(sockfd_, buffer, sizeof(buffer), 0);
+                if (opcode == 0x01) {  // TEXT frame
+                    topic.clear();
+                    payload.clear();
 
-        if (n <= 0) {
-            return false;
-        }
+                    size_t topic_pos = frame_payload.find("\"topic\":\"");
+                    if (topic_pos != std::string::npos) {
+                        topic_pos += 9;
+                        size_t topic_end = frame_payload.find("\"", topic_pos);
+                        topic = frame_payload.substr(topic_pos, topic_end - topic_pos);
+                    }
 
-        // Parse WebSocket frame
-        uint8_t opcode;
-        std::string frame_payload;
-        if (!parse_websocket_frame(buffer, n, opcode, frame_payload)) {
-            std::cerr << "Failed to parse frame" << std::endl;
-            return false;
-        }
+                    size_t payload_pos = frame_payload.find("\"payload\":\"");
+                    if (payload_pos != std::string::npos) {
+                        payload_pos += 11;
+                        size_t payload_end = frame_payload.find("\"", payload_pos);
+                        // The bridge base64-encodes payloads on the way out.
+                        payload = base64_decode(
+                            frame_payload.substr(payload_pos, payload_end - payload_pos));
+                    }
 
-        // Handle different frame types
-        if (opcode == 0x01) {  // TEXT frame
-            // Parse JSON
-            size_t topic_pos = frame_payload.find("\"topic\":\"");
-            if (topic_pos != std::string::npos) {
-                topic_pos += 9;
-                size_t topic_end = frame_payload.find("\"", topic_pos);
-                topic = frame_payload.substr(topic_pos, topic_end - topic_pos);
+                    std::cout << "Received message on topic '" << topic << "': " << payload
+                              << std::endl;
+                    return true;
+                }
+
+                if (opcode == 0x09) {  // PING
+                    std::vector<uint8_t> pong = create_websocket_frame(0x0A, frame_payload);
+                    send(sockfd_, pong.data(), pong.size(), 0);
+                }
             }
 
-            size_t payload_pos = frame_payload.find("\"payload\":\"");
-            if (payload_pos != std::string::npos) {
-                payload_pos += 11;
-                size_t payload_end = frame_payload.find("\"", payload_pos);
-                payload = frame_payload.substr(payload_pos, payload_end - payload_pos);
+            struct timeval tv;
+            tv.tv_sec = timeout_ms / 1000;
+            tv.tv_usec = (timeout_ms % 1000) * 1000;
+            setsockopt(sockfd_, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+            uint8_t buffer[65536];
+            ssize_t n = recv(sockfd_, buffer, sizeof(buffer), 0);
+            if (n <= 0) {
+                return false;
             }
 
-            std::cout << "Received message on topic '" << topic << "': " << payload << std::endl;
-            return true;
-        } else if (opcode == 0x09) {  // PING
-            // Send PONG
-            std::vector<uint8_t> pong = create_websocket_frame(0x0A, frame_payload);
-            send(sockfd_, pong.data(), pong.size(), 0);
-            return receive_message(topic, payload, timeout_ms);
+            recv_buffer_.insert(recv_buffer_.end(), buffer, buffer + n);
         }
-
-        return false;
     }
 
     bool send_ping() {
@@ -412,6 +448,13 @@ private:
             return false;
         }
 
+        // Anything the same read picked up after the header block is frame data.
+        size_t body_start = headers_end + 4;
+        if (static_cast<size_t>(n) > body_start) {
+            const uint8_t* bytes = reinterpret_cast<const uint8_t*>(buffer);
+            recv_buffer_.insert(recv_buffer_.end(), bytes + body_start, bytes + n);
+        }
+
         std::cout << "WebSocket handshake successful" << std::endl;
         return true;
     }
@@ -420,6 +463,7 @@ private:
     int port_;
     int sockfd_;
     bool connected_;
+    std::vector<uint8_t> recv_buffer_;
 };
 
 // Test functions

--- a/src/session/mqtt_session_manager_v2.cpp
+++ b/src/session/mqtt_session_manager_v2.cpp
@@ -973,18 +973,14 @@ int GlobalSessionManager::forward_publish_by_topic(const MQTTString& topic,
   int ret = find_topic_subscribers(topic, subscribers);
   if (MQ_FAIL(ret)) {
     LOG_ERROR("Failed to find subscribers for topic: {}", from_mqtt_string(topic));
-    return 0;
+    return ret;
   }
 
   int forwarded_count = 0;
 
-  std::string sender_id = from_mqtt_string(sender_client_id);
+  // 发布者自己订阅了该主题时同样要收到消息：MQTT 3.1.1 没有例外，MQTT 5 也只有在
+  // 订阅时显式设置 No Local 才不投递，而当前订阅选项里还没有解析 No Local。
   for (const SubscriberInfo& subscriber : subscribers) {
-    // 避免回环
-    if (from_mqtt_string(subscriber.client_id) == sender_id) {
-      continue;
-    }
-
     if (forward_publish(subscriber.client_id, packet, sender_client_id) == MQ_SUCCESS) {
       forwarded_count++;
     }
@@ -993,7 +989,7 @@ int GlobalSessionManager::forward_publish_by_topic(const MQTTString& topic,
   LOG_DEBUG("Forwarded PUBLISH message to {} subscribers for topic: {}", forwarded_count,
             from_mqtt_string(topic));
 
-  return ret;
+  return forwarded_count;
 }
 
 int GlobalSessionManager::forward_publish_by_topic_shared(const MQTTString& topic,
@@ -1009,7 +1005,7 @@ int GlobalSessionManager::forward_publish_by_topic_shared(const MQTTString& topi
   int ret = find_topic_subscribers(topic, subscribers);
   if (MQ_FAIL(ret)) {
     LOG_ERROR("Failed to find subscribers for topic: {}", from_mqtt_string(topic));
-    return 0;
+    return ret;
   }
 
   if (subscribers.empty()) {
@@ -1017,24 +1013,15 @@ int GlobalSessionManager::forward_publish_by_topic_shared(const MQTTString& topi
     return 0;
   }
 
-  // 过滤掉发送者自己（避免回环）
-  std::vector<MQTTString> filtered_subscribers;
-  std::string sender_id = from_mqtt_string(content->sender_client_id);
-
+  // 与 forward_publish_by_topic 一致：发布者自己也在订阅者之列时照常投递。
+  std::vector<MQTTString> target_subscribers;
+  target_subscribers.reserve(subscribers.size());
   for (const SubscriberInfo& subscriber : subscribers) {
-    if (from_mqtt_string(subscriber.client_id) != sender_id) {
-      filtered_subscribers.push_back(subscriber.client_id);
-    }
-  }
-
-  if (filtered_subscribers.empty()) {
-    LOG_DEBUG("No valid subscribers found for topic: {} (after filtering sender)",
-              from_mqtt_string(topic));
-    return 0;
+    target_subscribers.push_back(subscriber.client_id);
   }
 
   // 使用批量转发优化
-  int forwarded_count = batch_forward_publish(filtered_subscribers, content);
+  int forwarded_count = batch_forward_publish(target_subscribers, content);
 
   LOG_DEBUG("Forwarded shared PUBLISH message to {} subscribers for topic: {}", forwarded_count,
             from_mqtt_string(topic));
@@ -1835,6 +1822,10 @@ int GlobalSessionManager::forward_publish_cluster(const MQTTString& topic,
   bool strict_cluster_mode = false;
 
   delivered_count = forward_publish_by_topic(topic, packet, sender_client_id);
+  if (delivered_count < 0) {
+    return delivered_count;
+  }
+
   router_enabled = (router_client_.get() != NULL);
   strict_cluster_mode = cluster_config_.cluster_enabled;
   if (!router_enabled) {

--- a/src/session/mqtt_session_manager_v2.h
+++ b/src/session/mqtt_session_manager_v2.h
@@ -245,12 +245,18 @@ class GlobalSessionManager
 
   /**
    * @brief 转发PUBLISH消息到订阅指定主题的所有客户端
+   *
+   * 发布者自己订阅了该主题时也在投递范围内。
+   *
+   * @return 非负数为投递成功的客户端数量，负数为错误码。
    */
   int forward_publish_by_topic(const MQTTString& topic, const PublishPacket& packet,
                                const MQTTString& sender_client_id);
 
   /**
    * @brief 转发PUBLISH消息到订阅指定主题的所有客户端（使用共享内容，内存优化版本）
+   *
+   * @return 非负数为投递成功的客户端数量，负数为错误码。
    */
   int forward_publish_by_topic_shared(const MQTTString& topic,
                                       const SharedMessageContentPtr& content);

--- a/src/websocket/websocket_mqtt_bridge.cpp
+++ b/src/websocket/websocket_mqtt_bridge.cpp
@@ -713,13 +713,14 @@ int WebSocketMQTTBridge::publish_message(const std::string& client_id, const std
     // Forward to MQTT broker via session manager
     mqtt::MQTTString mqtt_topic = mqtt::to_mqtt_string(topic, allocator_);
     mqtt::MQTTString mqtt_client_id = mqtt::to_mqtt_string(client_id, allocator_);
-    int ret = session_manager_->forward_publish_by_topic(mqtt_topic, packet, mqtt_client_id);
-
-    if (ret == MQ_SUCCESS) {
-        stats_.mqtt_messages_sent++;
+    // 非负返回值是投递成功的订阅者数量，不是错误码。
+    int delivered_count = session_manager_->forward_publish_by_topic(mqtt_topic, packet, mqtt_client_id);
+    if (delivered_count < 0) {
+        return delivered_count;
     }
 
-    return ret;
+    stats_.mqtt_messages_sent += delivered_count;
+    return MQ_SUCCESS;
 }
 
 // MQTT packet handlers (for binary protocol mode)

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -67,6 +67,12 @@ add_executable(test_session_manager_stress test_session_manager_stress.cpp
     ${CMAKE_SOURCE_DIR}/src/core/mqtt_protocol_handler.cpp
     ${CMAKE_SOURCE_DIR}/src/core/mqtt_socket.cpp
     ${CMAKE_SOURCE_DIR}/src/common/logger.cpp)
+add_executable(test_session_publish_routing test_session_publish_routing.cpp
+    ${CMAKE_SOURCE_DIR}/src/session/mqtt_session_manager_v2.cpp
+    ${CMAKE_SOURCE_DIR}/src/memory/mqtt_allocator.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/mqtt_protocol_handler.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/mqtt_socket.cpp
+    ${CMAKE_SOURCE_DIR}/src/common/logger.cpp)
 
 # 添加转发连接池测试
 add_executable(test_mqtt_forwarding_pool test_mqtt_forwarding_pool.cpp)
@@ -110,6 +116,7 @@ target_include_directories(test_mqtt_session_manager_memory PRIVATE ${TEST_INCLU
 target_include_directories(test_simple_memory PRIVATE ${TEST_INCLUDE_DIRS} ${YAML_CPP_INCLUDE_DIRS})
 target_include_directories(test_session_manager_allocator PRIVATE ${TEST_INCLUDE_DIRS} ${YAML_CPP_INCLUDE_DIRS})
 target_include_directories(test_session_manager_stress PRIVATE ${TEST_INCLUDE_DIRS} ${YAML_CPP_INCLUDE_DIRS})
+target_include_directories(test_session_publish_routing PRIVATE ${TEST_INCLUDE_DIRS} ${YAML_CPP_INCLUDE_DIRS})
 
 # 认证系统测试的头文件搜索路径
 target_include_directories(test_mqtt_auth_manager PRIVATE ${TEST_INCLUDE_DIRS} ${YAML_CPP_INCLUDE_DIRS})
@@ -150,6 +157,7 @@ target_link_libraries(test_mqtt_session_manager_memory PRIVATE mqtt_runtime mqtt
 target_link_libraries(test_simple_memory PRIVATE mqtt_runtime mqtt_parser mqtt_router mqtt_auth tcmalloc_minimal gtest pthread dl -Wl,-Bstatic ${YAML_CPP_STATIC_LIBRARIES} -Wl,-Bdynamic)
 target_link_libraries(test_session_manager_allocator PRIVATE mqtt_runtime mqtt_parser mqtt_router mqtt_auth tcmalloc_minimal gtest pthread dl -Wl,-Bstatic ${YAML_CPP_STATIC_LIBRARIES} -Wl,-Bdynamic)
 target_link_libraries(test_session_manager_stress PRIVATE mqtt_runtime mqtt_parser mqtt_router mqtt_auth tcmalloc_minimal gtest pthread dl -Wl,-Bstatic ${YAML_CPP_STATIC_LIBRARIES} -Wl,-Bdynamic)
+target_link_libraries(test_session_publish_routing PRIVATE mqtt_runtime mqtt_parser mqtt_router mqtt_auth tcmalloc_minimal gtest pthread dl -Wl,-Bstatic ${YAML_CPP_STATIC_LIBRARIES} -Wl,-Bdynamic)
 
 # 认证系统测试的链接库
 target_link_libraries(test_mqtt_auth_manager PRIVATE mqtt_auth mqtt_runtime tcmalloc_minimal gtest pthread dl -Wl,-Bstatic ${YAML_CPP_STATIC_LIBRARIES} -Wl,-Bdynamic)
@@ -190,6 +198,7 @@ add_test(NAME test_mqtt_session_manager_optimization COMMAND test_mqtt_session_m
 add_test(NAME test_mqtt_session_manager_memory COMMAND test_mqtt_session_manager_memory)
 add_test(NAME test_session_manager_allocator COMMAND test_session_manager_allocator)
 add_test(NAME test_session_manager_stress COMMAND test_session_manager_stress)
+add_test(NAME test_session_publish_routing COMMAND test_session_publish_routing)
 
 # 添加转发连接池测试
 add_test(NAME test_mqtt_forwarding_pool COMMAND test_mqtt_forwarding_pool)

--- a/unittest/test_session_publish_routing.cpp
+++ b/unittest/test_session_publish_routing.cpp
@@ -1,0 +1,122 @@
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+#include "coroutine_test_helper.h"
+#include "logger.h"
+#include "mqtt_allocator.h"
+#include "mqtt_define.h"
+#include "mqtt_memory_tags.h"
+#include "mqtt_packet.h"
+#include "mqtt_protocol_handler.h"
+#include "mqtt_session_manager_v2.h"
+
+using namespace mqtt;
+
+namespace {
+
+class RoutingMockHandler : public MQTTProtocolHandler
+{
+ public:
+  explicit RoutingMockHandler(const std::string& client_id)
+      : MQTTProtocolHandler(MQTTMemoryManager::get_instance().get_root_allocator())
+  {
+    set_client_id(to_mqtt_string(client_id, MQTTMemoryManager::get_instance().get_root_allocator()));
+  }
+};
+
+class PublishRoutingTest : public ::testing::Test
+{
+ protected:
+  void SetUp() override
+  {
+    coro_scope_.reset(new mqtt::test::CoroutineTestScope());
+    if (!coro_scope_->is_available()) {
+      GTEST_SKIP() << "Coroutine runtime is not available in this environment";
+    }
+
+    manager_.reset(new GlobalSessionManager());
+    ASSERT_EQ(MQ_SUCCESS, manager_->pre_register_threads(1, 100));
+
+    thread_manager_ = manager_->register_thread_manager(std::this_thread::get_id());
+    ASSERT_NE(nullptr, thread_manager_);
+    ASSERT_EQ(MQ_SUCCESS, manager_->finalize_thread_registration());
+
+    allocator_ = thread_manager_->get_allocator();
+  }
+
+  void TearDown() override
+  {
+    handlers_.clear();
+    manager_.reset();
+    coro_scope_.reset();
+    MQTTMemoryManager::cleanup_thread_local();
+  }
+
+  void add_subscriber(const std::string& client_id, const std::string& topic_filter)
+  {
+    handlers_.push_back(
+        std::unique_ptr<RoutingMockHandler>(new RoutingMockHandler(client_id)));
+
+    MQTTString mqtt_client_id = to_mqtt_string(client_id, allocator_);
+    ASSERT_EQ(MQ_SUCCESS, manager_->register_session(mqtt_client_id, handlers_.back().get()));
+    ASSERT_EQ(MQ_SUCCESS,
+              manager_->subscribe_topic(to_mqtt_string(topic_filter, allocator_), mqtt_client_id, 0));
+  }
+
+  int publish(const std::string& topic, const std::string& sender_client_id)
+  {
+    PublishPacket packet(allocator_);
+    packet.type = PacketType::PUBLISH;
+    packet.topic_name = to_mqtt_string(topic, allocator_);
+    packet.qos = 0;
+
+    return manager_->forward_publish_by_topic(packet.topic_name, packet,
+                                              to_mqtt_string(sender_client_id, allocator_));
+  }
+
+  std::unique_ptr<mqtt::test::CoroutineTestScope> coro_scope_;
+  std::unique_ptr<GlobalSessionManager> manager_;
+  ThreadLocalSessionManager* thread_manager_ = nullptr;
+  MQTTAllocator* allocator_ = nullptr;
+  std::vector<std::unique_ptr<RoutingMockHandler>> handlers_;
+};
+
+// 发布者自己订阅了目标主题时必须收到自己发布的消息：MQTT 3.1.1 没有例外，MQTT 5 也
+// 只有显式设置 No Local 才不投递。
+TEST_F(PublishRoutingTest, PublisherReceivesItsOwnMessageWhenSubscribed)
+{
+  add_subscriber("self_publisher", "routing/self");
+
+  size_t before = thread_manager_->get_pending_message_count();
+  EXPECT_EQ(1, publish("routing/self", "self_publisher"));
+  EXPECT_EQ(before + 1, thread_manager_->get_pending_message_count());
+}
+
+TEST_F(PublishRoutingTest, DeliversToEverySubscriberIncludingThePublisher)
+{
+  add_subscriber("publisher", "routing/shared");
+  add_subscriber("listener", "routing/shared");
+
+  size_t before = thread_manager_->get_pending_message_count();
+  EXPECT_EQ(2, publish("routing/shared", "publisher"));
+  EXPECT_EQ(before + 2, thread_manager_->get_pending_message_count());
+}
+
+TEST_F(PublishRoutingTest, ReportsZeroWhenNobodySubscribed)
+{
+  add_subscriber("listener", "routing/other");
+
+  size_t before = thread_manager_->get_pending_message_count();
+  EXPECT_EQ(0, publish("routing/unmatched", "publisher"));
+  EXPECT_EQ(before, thread_manager_->get_pending_message_count());
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
跟进 #11 review 里记为 P2 的最后一项：WebSocket bridge 的 publish/subscribe 日志出现 `Forwarded PUBLISH message to 0 subscribers`。

> 本分支基于 #13，等 #13 合并后 GitHub 会自动把 base 切回 `main`。

## 根因

不是 WebSocket 的问题。`GlobalSessionManager::forward_publish_by_topic()` 会把发布者自己从订阅者列表里过滤掉（注释写的是"避免回环"）。MQTT 3.1.1 没有这个例外，MQTT 5 也只有在订阅时显式设置 No Local 才不投递，而当前 `parse_subscribe` 把订阅选项字节直接 `& 0x03`，No Local 根本没被读出来。

`simple_websocket_mqtt_test` 用同一个连接既订阅又发布，因此每个用例都拿不到消息。用两个连接验证过：跨客户端投递一直是正常的，只有自投递被吃掉。

普通 MQTT 连接同样受影响（`paho-mqtt` 单连接订阅 + 发布同一主题，收不到）。

## 改动

1. `forward_publish_by_topic()` / `forward_publish_by_topic_shared()` 不再过滤发布者。
2. 顺带修同一条路径上的返回值问题：
   - `forward_publish_by_topic()` 之前返回的是 `find_topic_subscribers()` 的错误码（成功时恒为 0），而 `forward_publish_cluster()` 和 `MQTTForwardingService` 都把它当投递数量用，本地投递数因此永远是 0；查找失败时又 `return 0` 把错误吞掉。现在统一为"非负是数量，负数是错误码"，并在 `forward_publish_cluster()` 里对负值提前返回。
   - `WebSocketMQTTBridge::publish_message()` 之前把返回值当错误码比较，改为按数量处理。
3. 新增 `test_session_publish_routing`：自订阅收到自己的消息、多订阅者时投递数包含发布者、无人订阅返回 0。把旧的过滤逻辑加回去后前两个用例会失败。
4. 修 `simple_websocket_mqtt_test` 客户端自身的两个 bug（不改协议，只改测试客户端）：
   - 一次 `recv` 可能带回多个 WebSocket 帧，原先只解析首帧、其余字节丢弃，所以连发 5 条只能收到 1 条。
   - bridge 出方向的 JSON payload 是 base64 的，客户端拿编码后的串和原文比较，永远判 wrong data。

## 验证

`ctest` 53/53 通过（含新增用例）。

`simple_websocket_mqtt_test` 修复前后：

```
# 修复前
=== Test 1: Publish/Subscribe ===
✗ Publish/Subscribe test FAILED (no message received)
=== Test 2: Multiple Messages ===
✗ Multiple messages test FAILED (received 0/5)
=== Test 4: QoS Levels ===        ✗ QoS test FAILED
=== Test 5: Wildcard Topics ===   ✗ Wildcard topics test FAILED (received 0 messages)

# 修复后
✓ Publish/Subscribe test PASSED
✓ Multiple messages test PASSED (received 5/5)
✓ Ping/Pong test PASSED
✓ QoS test PASSED (received 2 messages)
✓ Wildcard topics test PASSED (received 2 messages)
```

普通 MQTT（paho-mqtt，单连接订阅 + 发布同一主题）：修复前 `NOTHING RECEIVED`，修复后 `[('selfcheck/topic', 'hello-self')]`。

## 未包含

- MQTT 5 的 No Local 订阅选项仍未支持：解析、topic tree 的订阅项、router 侧的持久化都要跟着改，等真正实现后可以按订阅选项有条件地恢复过滤。
- `mqtt_server.cpp` 里 WebSocket bridge 的 `MessageFormat` 是写死的 `JSON`，没读 `mqtts.yaml` 的 `websocket.message_format`，属另一个既有问题。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b51b5c5c-058f-49cf-bb7d-d17da74bc555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b51b5c5c-058f-49cf-bb7d-d17da74bc555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

